### PR TITLE
fix: correct isolated-crustaion typo

### DIFF
--- a/docs/plans/2026-03-07-mcp-server-support.md
+++ b/docs/plans/2026-03-07-mcp-server-support.md
@@ -12,7 +12,7 @@
 
 ### Task 1: Name the internal network explicitly
 
-The `internal` network in `docker-compose.yml` uses compose's auto-generated name (e.g., `isolated-crustaion_internal`). Override files need to reference it with `external: true`, which requires a stable, explicit name.
+The `internal` network in `docker-compose.yml` uses compose's auto-generated name (e.g., `isolated-crustacean_internal`). Override files need to reference it with `external: true`, which requires a stable, explicit name.
 
 **Files:**
 - Modify: `docker-compose.yml:26-29`

--- a/hermit
+++ b/hermit
@@ -97,7 +97,7 @@ case "${1:-}" in
             _run_args+=(-v "${_abs_path}:/home/node/workspace")
         elif [[ -f "$SCRIPT_DIR/.hermit-workspace" ]]; then
             _ws_name="$(cat "$SCRIPT_DIR/.hermit-workspace")"
-            _run_args+=(-v "isolated-crustaion-${_ws_name}:/home/node/workspace")
+            _run_args+=(-v "isolated-crustacean-${_ws_name}:/home/node/workspace")
         fi
         compose_cmd run --rm "${_run_args[@]+"${_run_args[@]}"}" claude-code
         ;;
@@ -374,7 +374,7 @@ case "${1:-}" in
     workspace)
         shift
         _ws_subcmd="${1:-list}"
-        _vol_prefix="isolated-crustaion"
+        _vol_prefix="isolated-crustacean"
         case "$_ws_subcmd" in
             list)
                 docker volume ls --filter "name=${_vol_prefix}" --format "table {{.Name}}\t{{.Driver}}\t{{.Mountpoint}}"

--- a/tests/workspace.bats
+++ b/tests/workspace.bats
@@ -9,8 +9,8 @@ setup() {
 }
 
 teardown() {
-    # Clean up any test volumes (hermit prepends "isolated-crustaion-")
-    docker volume ls --filter "name=isolated-crustaion-${_test_vol_prefix}" -q | xargs -r docker volume rm 2>/dev/null || true
+    # Clean up any test volumes (hermit prepends "isolated-crustacean-")
+    docker volume ls --filter "name=isolated-crustacean-${_test_vol_prefix}" -q | xargs -r docker volume rm 2>/dev/null || true
     rm -f "$COMPOSE_PROJECT_DIR/.hermit-workspace"
 }
 
@@ -22,7 +22,7 @@ teardown() {
 @test "workspace create makes a new volume" {
     run "$HERMIT" workspace create "$_test_name"
     [ "$status" -eq 0 ]
-    run docker volume inspect "isolated-crustaion-${_test_name}"
+    run docker volume inspect "isolated-crustacean-${_test_name}"
     [ "$status" -eq 0 ]
 }
 
@@ -48,7 +48,7 @@ teardown() {
     "$HERMIT" workspace create "$_test_name"
     run bash -c "echo y | '$HERMIT' workspace rm '$_test_name'"
     [ "$status" -eq 0 ]
-    run docker volume inspect "isolated-crustaion-${_test_name}"
+    run docker volume inspect "isolated-crustacean-${_test_name}"
     [ "$status" -ne 0 ]
 }
 


### PR DESCRIPTION
## Summary
- Rename `isolated-crustaion` → `isolated-crustacean` in `hermit` workspace volume prefix and tests
- Fix matching reference in `docs/plans/2026-03-07-mcp-server-support.md`
- No existing `isolated-crustaion-<name>` workspace volumes were found locally, so no migration needed

## Test plan
- [ ] `bats tests/workspace.bats` passes
- [ ] `./hermit workspace list` works on a fresh repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)